### PR TITLE
fix blue buttons, translate back to meetings

### DIFF
--- a/src/components/Meeting.tsx
+++ b/src/components/Meeting.tsx
@@ -3,26 +3,26 @@ import {
   Button as ChakraButton,
   Heading,
   Stack,
-  Text,
   Tag,
+  Text,
   useColorModeValue
 } from '@chakra-ui/react';
 import Highlighter from 'react-highlight-words';
 import Linkify from 'react-linkify';
 import { Link } from 'react-router-dom';
 
+import {
+  MeetingLink,
+  Meeting as MeetingType,
+  formatTime,
+  sanitizeQuotes,
+  useData,
+  useI18n,
+  useInput
+} from '../helpers';
 import { Button } from './Button';
 import { Group } from './Group';
 import { Icon } from './Icon';
-import {
-  Meeting as MeetingType,
-  MeetingLink,
-  formatTime,
-  useData,
-  useI18n,
-  useInput,
-  sanitizeQuotes
-  } from '../helpers';
 
 export function Meeting({
   link,
@@ -54,7 +54,7 @@ export function Meeting({
     buttons.push({
       icon: 'video',
       value: conference_provider,
-      onClick: () => window.open(conference_url),
+      href: conference_url,
       notes: conference_url_notes,
       title: strings.video_use.replace('{{value}}', conference_url)
     });
@@ -63,14 +63,18 @@ export function Meeting({
     buttons.push({
       icon: 'phone',
       value: strings.telephone,
-      onClick: () => window.open(`tel:${conference_phone}`),
+      href: `tel:${conference_phone}`,
       notes: conference_phone_notes,
       title: strings.telephone_use.replace('{{value}}', conference_phone)
     });
   }
 
   const title = input.searchWords?.length ? (
-    <Highlighter searchWords={input.searchWords} textToHighlight={name} sanitize={sanitizeQuotes}/>
+    <Highlighter
+      searchWords={input.searchWords}
+      textToHighlight={name}
+      sanitize={sanitizeQuotes}
+    />
   ) : (
     name
   );

--- a/src/components/SingleMeeting.tsx
+++ b/src/components/SingleMeeting.tsx
@@ -1,16 +1,17 @@
-import { useLoaderData, useLocation, useNavigate } from 'react-router-dom';
 import { Stack } from '@chakra-ui/react';
+import { useLoaderData, useLocation, useNavigate } from 'react-router-dom';
 
+import { useData, useI18n } from '../helpers';
 import { Button } from './Button';
 import { Error } from './Error';
 import { Meeting } from './Meeting';
-import { useData } from '../helpers';
 
 export function SingleMeeting() {
   const navigate = useNavigate();
   const { key } = useLocation();
   const request = useLoaderData();
   const { meetings } = useData();
+  const { strings } = useI18n();
 
   const meeting = request
     ? meetings.find(({ slug }) => slug === request)
@@ -28,7 +29,7 @@ export function SingleMeeting() {
           }
         }}
       >
-        Back to Meetings
+        {strings.back_to_meetings}
       </Button>
       {meeting ? (
         <Meeting meeting={meeting} />

--- a/src/helpers/calendar.ts
+++ b/src/helpers/calendar.ts
@@ -61,7 +61,7 @@ export function formatIcs(meeting: Meeting & { group: Group }) {
   if (iOS()) {
     // create data url for ios
     const uri = `data:text/calendar;charset=utf8,${blob}`;
-    window.location = encodeURI(uri) as unknown as Location;
+    window.location.href = encodeURI(uri);
   } else {
     // create temporary link to download
     const url = window.URL.createObjectURL(new Blob([blob]));

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -59,7 +59,7 @@ export type Meeting = {
 
 export type MeetingLink = {
   icon: 'link' | 'email' | 'phone' | 'video';
-  onClick: () => void;
+  href: string;
   value: string;
   title: string;
 };

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -17,6 +17,7 @@ export const en = {
   name: 'English',
   rtl: false,
   strings: {
+    back_to_meetings: 'Back to meetings',
     calendar: 'Calendar',
     clear_search: 'Clear search',
     close: 'Close',

--- a/src/languages/es.ts
+++ b/src/languages/es.ts
@@ -17,6 +17,7 @@ export const es = {
   name: 'Español',
   rtl: false,
   strings: {
+    back_to_meetings: 'Regreso a las reuniones',
     calendar: 'Calendario',
     clear_search: 'Borrar búsqueda',
     close: 'Cerrar',

--- a/src/languages/fr.ts
+++ b/src/languages/fr.ts
@@ -17,6 +17,7 @@ export const fr = {
   name: 'Français',
   rtl: false,
   strings: {
+    back_to_meetings: 'Retour aux réunions',
     calendar: 'Calendrier',
     clear_search: 'Effacer la recherche',
     close: 'Fermer',

--- a/src/languages/ja.ts
+++ b/src/languages/ja.ts
@@ -17,6 +17,7 @@ export const ja = {
   name: '日本語',
   rtl: false,
   strings: {
+    back_to_meetings: '会議に戻る',
     calendar: 'カレンダー',
     clear_search: '明確な検索',
     close: 'シャット',

--- a/src/languages/nl.ts
+++ b/src/languages/nl.ts
@@ -17,6 +17,7 @@ export const nl = {
   name: 'Nederlands',
   rtl: false,
   strings: {
+    back_to_meetings: 'Terug naar vergaderingen',
     calendar: 'Kalender',
     clear_search: 'Zoekopdracht wissen',
     close: 'Sluiten',
@@ -66,7 +67,7 @@ export const nl = {
     types: {
       ...nonLanguageTypes,
       'BV-I': 'Blind/Visueel gehandicapten',
-      'BV-D': 'Doven en slechthorenden',
+      'LO-I': 'Doven en slechthorenden',
       'D-HOH': 'Slechthorenden/Doven',
       LGBTQ: 'LGBTQIAA+',
       QSL: 'Quebec gebarentaal',

--- a/src/languages/pt.ts
+++ b/src/languages/pt.ts
@@ -17,6 +17,7 @@ export const pt = {
   name: 'Português',
   rtl: false,
   strings: {
+    back_to_meetings: 'Regresso às reuniões',
     calendar: 'Calendário',
     clear_search: 'Limpar pesquisa',
     close: 'Perto',

--- a/src/languages/sk.ts
+++ b/src/languages/sk.ts
@@ -17,6 +17,7 @@ export const sk = {
   name: 'Slovák',
   rtl: false,
   strings: {
+    back_to_meetings: 'Späť na stretnutia',
     calendar: 'Kalendár',
     clear_search: 'Vymazať vyhľadávanie',
     close: 'Zavrieť',

--- a/src/languages/sv.ts
+++ b/src/languages/sv.ts
@@ -17,6 +17,7 @@ export const sv = {
   name: 'Svenska',
   rtl: false,
   strings: {
+    back_to_meetings: 'Tillbaka till möten',
     calendar: 'Kalender',
     clear_search: 'Rensa sökningen',
     close: 'Stänga',


### PR DESCRIPTION
using `a href` appears to be a more reliable method of navigating than `button onClick`

this PR moves the blue buttons to use that method, as well as one of the gray calendar options that was missed in #79

while auditing the buttons, i noticed that the "back to meetings" button was not translated

also prettier made some formatting changes