### PR TITLE
Support runtime basename configuration via data attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a meeting finder designed to list online recovery meetings around the wo
    REACT_APP_JSON_URL="https://your-website.org/meetings.json"
    ```
 
-1. Open your terminal and run `npm i && npm run dev` to start the app in development mode.
+1. Open your terminal and run `npm i && npm start` to start the app in development mode.
 
 ## Deploy to your Website
 
@@ -28,12 +28,22 @@ This is a meeting finder designed to list online recovery meetings around the wo
 REACT_APP_BASE_URL="/meetings"
 ```
 
-1. In your terminal run `npm i && npm run build`.
-1. Copy the `/build/static` folder to your website.
-1. Add the following HTML to your web page (replace `chunk` below with the correct file name):
+You can also set the router basename at runtime on the root element (this overrides `REACT_APP_BASE_URL`):
 
 ```
-<script defer src="/static/js/main.chunk.js"></script>
+<div id="root" data-base-url="/fr/repertoire-des-reunions"></div>
+<script defer src="/static/js/online-meeting-list.js"></script>
+```
+
+Use this when embedding the app on localized or per-page URLs (for example WPML paths).
+
+
+1. In your terminal run `npm i && npm run build`.
+1. Copy the `/build/static` folder to your website.
+1. Add the following HTML to your web page:
+
+```
+<script defer src="/static/js/online-meeting-list.js"></script>
 <div id="root"></div>
 ```
 

--- a/src/helpers/baseUrl.ts
+++ b/src/helpers/baseUrl.ts
@@ -1,0 +1,16 @@
+const normalizeBasename = (value?: string | null) => {
+  if (!value) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '/') return '/';
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+};
+
+export const getRouterBasename = (container: HTMLElement) => {
+  const fromRoot = normalizeBasename(container.dataset.baseUrl);
+  if (fromRoot) return fromRoot;
+
+  return normalizeBasename(process.env.REACT_APP_BASE_URL);
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './analytics';
+export * from './baseUrl';
 export * from './calendar';
 export * from './config';
 export * from './data';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,12 +6,13 @@ import { DateTime } from 'luxon';
 
 import { App } from './App';
 import './index.css';
-import { getLanguage, load, parseSearchWords, theme } from './helpers';
+import { getLanguage, getRouterBasename, load, parseSearchWords, theme } from './helpers';
 import { Error as ErrorBoundary, Meetings, SingleMeeting } from './components';
 
 const container = document.getElementById('root');
 if (!container) throw new Error('Failed to find the root element');
 const root = ReactDOM.createRoot(container);
+const basename = getRouterBasename(container);
 
 const router = createBrowserRouter(
   [
@@ -52,7 +53,7 @@ const router = createBrowserRouter(
       ]
     }
   ],
-  { basename: process.env.REACT_APP_BASE_URL }
+  { basename }
 );
 
 root.render(


### PR DESCRIPTION
## Summary
Enables runtime configuration of the router basename through a `data-baseUrl` attribute on the root container element, in addition to the existing environment variable support.

## Overview
The `getRouterBasename` function now prioritizes the `data-baseUrl` dataset attribute on the root DOM element, with fallback to the `REACT_APP_BASE_URL` environment variable. This allows basename configuration at runtime without requiring a rebuild.

## Benefits
- Enables dynamic basename configuration for different deployment environments
- No rebuild needed to change the router basename
- Maintains backward compatibility with existing `REACT_APP_BASE_URL` environment variable
- Follows the existing fallback pattern: data attribute → env var → undefined

## Usage
Set the basename on the root element:
```html
<div id="root" data-baseUrl="/my-app/"></div>
```
Or continue using environment variables:

```REACT_APP_BASE_URL=/meetings/```